### PR TITLE
Add Python-based image description plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ specifically on enriching images with descriptive text.
 ## 🧰 Features
 
 - 🖼️ Generates alt text for images in your vault
-- 🤖 Uses a pluggable AI service for descriptions
+- 🤖 Uses Ollama to generate descriptions with local models
 - 📑 Stores results alongside the original image reference
-- ⚙️ Built with TypeScript and a VaultOS-friendly layout
+- ⚙️ Written in Python and designed for a VaultOS-friendly layout
 - 💬 GitHub Actions and community links for collaboration
+- 🔄 Several generation modes (Pinterest Pin, Stable Diffusion prompt, ekphrasis, brief, detailed, text extraction, Midjourney prompt, technical art style, academic analysis)
 
 ---
 
@@ -37,23 +38,42 @@ cd vault-image-description
 ### 🛠 Local Setup
 
 ```bash
-npm install
-npm run build
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
 ```
 
-After building, copy the contents of `/dist` into your Obsidian vault’s `.obsidian/plugins/` folder.
+Run the `vault_image_description` plugin from your vault directory:
+
+```bash
+python -m vault_image_description.plugin <path-to-image>
+```
 
 ---
 
 ## 🧱 Folder Structure
 
 ```plaintext
-src/           → TypeScript plugin source
-dist/          → Compiled output used by Obsidian
+src/           → Python package containing the plugin
+dist/          → Compiled output or scripts for Obsidian (optional)
 ops/           → Plugin orchestration logic
 config/        → Static metadata and module configs
 .github/       → GitHub Actions, PR/issue templates
 ```
+
+## 🎨 Description Modes
+
+The plugin can generate image descriptions in multiple styles:
+
+- **pinterest_pin** – title, catchy caption, and hashtags in the PtiCalin voice.
+- **stable_diffusion_prompt** – a prompt ready for Stable Diffusion.
+- **ekphrasis** – poetic description inspired by the image.
+- **brief** – a short overview.
+- **detailed** – a thorough description.
+- **extract_text** – OCR text found inside the image.
+- **midjourney_prompt** – prompt for Midjourney.
+- **technical_artstyle** – technical art style analysis.
+- **analysis** – academic review of the image.
 
 ---
 

--- a/change-log.md
+++ b/change-log.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-05-30
+
+- Add Python implementation for generating image descriptions with Ollama
+- Support multiple generation modes including Pinterest pins and prompts
+- Added CLI script and requirements file
+
 ## [0.1.0] - YYYY-MM-DD
 
 - Initial scaffold with PtiCalin skeleton files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ollama
+pillow
+pytesseract

--- a/src/vault_image_description/__init__.py
+++ b/src/vault_image_description/__init__.py
@@ -1,0 +1,1 @@
+"""Vault Image Description plugin"""

--- a/src/vault_image_description/engine.py
+++ b/src/vault_image_description/engine.py
@@ -1,0 +1,38 @@
+import base64
+import io
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+import ollama
+import pytesseract
+
+from .modes import Mode, PROMPTS
+
+
+def encode_image(path: Path) -> str:
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode()
+
+
+def extract_text(image_path: Path) -> str:
+    image = Image.open(image_path)
+    return pytesseract.image_to_string(image)
+
+
+def generate(image_path: str, mode: Mode, model: str = "llava") -> str:
+    path = Path(image_path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    if mode == Mode.EXTRACT_TEXT:
+        return extract_text(path)
+
+    image_data = encode_image(path)
+    prompt = PROMPTS[mode]
+    messages = [
+        {"role": "user", "content": prompt},
+        {"role": "user", "content": image_data, "images": [image_data]},
+    ]
+    response = ollama.chat(model=model, messages=messages)
+    return response["message"]["content"].strip()

--- a/src/vault_image_description/modes.py
+++ b/src/vault_image_description/modes.py
@@ -1,0 +1,34 @@
+from enum import Enum
+
+class Mode(Enum):
+    PINTEREST_PIN = "pinterest_pin"
+    STABLE_DIFFUSION_PROMPT = "stable_diffusion_prompt"
+    EKPHRASIS = "ekphrasis"
+    BRIEF = "brief"
+    DETAILED = "detailed"
+    EXTRACT_TEXT = "extract_text"
+    MIDJOURNEY_PROMPT = "midjourney_prompt"
+    TECHNICAL_ARTSTYLE = "technical_artstyle"
+    ANALYSIS = "analysis"
+
+PROMPTS = {
+    Mode.PINTEREST_PIN: (
+        "You are PtiCalin. Generate a trendy Pinterest pin. Provide a short title,"
+        " a catchy caption in the PtiCalin voice, and several aesthetic hashtags."),
+    Mode.STABLE_DIFFUSION_PROMPT: (
+        "Describe this image as a stable diffusion prompt."),
+    Mode.EKPHRASIS: (
+        "Write an ekphrastic description of this image."),
+    Mode.BRIEF: (
+        "Describe this image briefly."),
+    Mode.DETAILED: (
+        "Provide a detailed description of this image."),
+    Mode.EXTRACT_TEXT: (
+        "Extract any text visible in the image."),
+    Mode.MIDJOURNEY_PROMPT: (
+        "Describe this image as a Midjourney prompt."),
+    Mode.TECHNICAL_ARTSTYLE: (
+        "Explain the technical art style used in this image."),
+    Mode.ANALYSIS: (
+        "Provide an academic analysis of this image."),
+}

--- a/src/vault_image_description/plugin.py
+++ b/src/vault_image_description/plugin.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from typing import Iterable
+
+from .engine import generate
+from .modes import Mode
+
+
+def describe_images(image_paths: Iterable[str], mode: Mode = Mode.BRIEF, model: str = "llava") -> dict:
+    results = {}
+    for path in image_paths:
+        try:
+            results[path] = generate(path, mode, model=model)
+        except Exception as e:
+            results[path] = f"Error: {e}"
+    return results
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate image descriptions with Ollama")
+    parser.add_argument("images", nargs="+", help="Image file paths")
+    parser.add_argument("--mode", default=Mode.BRIEF.value, choices=[m.value for m in Mode])
+    parser.add_argument("--model", default="llava", help="Ollama model name")
+    args = parser.parse_args()
+
+    mode = Mode(args.mode)
+    results = describe_images(args.images, mode=mode, model=args.model)
+    for path, desc in results.items():
+        print(f"{path}:\n{desc}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement Python package `vault_image_description` for generating descriptions with Ollama
- support several generation modes and OCR text extraction
- add CLI entry point and dependency list
- document features, setup instructions, and modes in the README
- record release notes in the changelog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684218467ff883229c5baaf110905eb5