### PR TITLE
Add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 __pycache__/
 .vscode/
 .DS_Store
+.venv/


### PR DESCRIPTION
## Summary
- ignore Python virtual environments

