### PR TITLE
Fix CI workflow to invoke setup script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,7 @@ jobs:
 
     steps:
       - name: 📦 Install dependencies
-        run: | #List dependencies here
-          echo "Installing dependencies..."
-          # Example: pip install -r requirements.txt
-          # Replace with actual commands for your project
+        env:
+          OFFLINE: 1
+        run: ./setup.sh
       


### PR DESCRIPTION
## Summary
- run `./setup.sh` with `OFFLINE=1` in CI
- drop placeholder install comments