### PR TITLE
Improve docs for engine module

### DIFF
--- a/src/vault_image_description/engine.py
+++ b/src/vault_image_description/engine.py
@@ -1,3 +1,11 @@
+# =======================================
+#  Vault Image Description Engine
+# ---------------------------------------
+#  Dependencies: Pillow, pytesseract, ollama
+#  Output: OCR text or alt text strings from Ollama
+# =======================================
+
+
 import base64
 import io
 from pathlib import Path
@@ -11,19 +19,64 @@ from .modes import Mode, PROMPTS
 
 
 def encode_image(path: Path) -> str:
+    """🔒 Encode an image in base64.
+
+    Parameters
+    ----------
+    path : Path
+        📁 Location of the image file.
+
+    Returns
+    -------
+    str
+        🎨 Base64 string ready for Ollama.
+    """
+
     with open(path, "rb") as f:
         return base64.b64encode(f.read()).decode()
 
 
 def extract_text(image_path: Path) -> str:
+    """📝 Grab visible text from an image.
+
+    Parameters
+    ----------
+    image_path : Path
+        📷 Path to the image we want to read.
+
+    Returns
+    -------
+    str
+        🖨️ Text spotted in the picture.
+    """
+
     image = Image.open(image_path)
     return pytesseract.image_to_string(image)
 
 
 def generate(image_path: str, mode: Mode, model: str = "llava") -> str:
+    """✨ Produce a description using Ollama.
+
+    Parameters
+    ----------
+    image_path : str
+        📍 File system path to the image.
+    mode : Mode
+        🎚️ Desired description mode.
+    model : str, optional
+        🤖 Ollama model name, by default "llava".
+
+    Returns
+    -------
+    str
+        📜 Generated alt text or extracted text.
+    """
+
     path = Path(image_path)
     if not path.exists():
-        raise FileNotFoundError(path)
+        raise FileNotFoundError(
+            f"Image not found at '{path}'. Please check the path and try again."
+        )
 
     if mode == Mode.EXTRACT_TEXT:
         return extract_text(path)


### PR DESCRIPTION
## Summary
- add header comment describing engine.py
- document encode_image, extract_text, and generate
- clarify missing file message in generate

## Testing
- `OFFLINE=1 ./setup.sh` *(fails: tsc missing due to offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_6845df27364c8322a515235064987e04