### PR TITLE
Generalize issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,5 @@
-name: 🪲 Bug Report (Vault Related)
-description: Report a bug or glitch inside the vault.
+name: "🪲 Bug Report"
+description: Report a bug or glitch you encountered in the project.
 title: 'Bug: {Issue Summary}'
 labels:
 - bug
@@ -16,7 +16,7 @@ body:
   id: where
   attributes:
     label: Where?
-    description: Page name, plugin, or workflow where the bug occurred.
+    description: File or module where the bug occurred.
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/cleanup.yml
+++ b/.github/ISSUE_TEMPLATE/cleanup.yml
@@ -1,4 +1,4 @@
-name: 🧹 Vault Cleanup
+name: "🧹 Cleanup"
 description: 'Schedule a cleaning session: archiving, deleting, merging.'
 title: 'Cleanup: {Scope}'
 labels:

--- a/.github/ISSUE_TEMPLATE/content.yml
+++ b/.github/ISSUE_TEMPLATE/content.yml
@@ -1,9 +1,9 @@
 name: ✍️ New Content Entry
-description: Log a new page, template, or section added to the vault.
+description: Log a new page, template, or section added to the project.
 title: 'New: {Page or Template Name}'
 labels:
 - new content
-- vault growth
+- project growth
 body:
 - type: textarea
   id: description
@@ -16,7 +16,7 @@ body:
   id: location
   attributes:
     label: Where is it located?
-    description: Folder/path inside the vault.
+    description: Folder/path inside the project.
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,5 +1,5 @@
 name: 🧭 Documentation Task
-description: Improve the README, wiki, or vault documentation.
+description: Improve the README, wiki, or other project documentation.
 title: 'Docs: {Area}'
 labels:
 - documentation

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: 🌟 Feature Request
-description: Suggest a new template, tool, workflow, or system for the vault.
+description: Suggest a new template, tool, workflow, or system for the project.
 title: 'Feature: {Idea}'
 labels:
 - feature request
@@ -16,7 +16,7 @@ body:
   id: benefit
   attributes:
     label: Why would it be useful?
-    description: Explain why this would improve the vault.
+    description: Explain why this would improve the project.
 - type: textarea
   id: notes
   attributes:

--- a/.github/ISSUE_TEMPLATE/goal-planning.yml
+++ b/.github/ISSUE_TEMPLATE/goal-planning.yml
@@ -1,5 +1,5 @@
 name: 🎯 Goal Planning
-description: Plan a focused vault goal.
+description: Plan a focused project goal.
 title: 'Goal: {Objective}'
 labels:
 - goal

--- a/.github/ISSUE_TEMPLATE/refractor.yml
+++ b/.github/ISSUE_TEMPLATE/refractor.yml
@@ -23,4 +23,4 @@ body:
   id: reasons
   attributes:
     label: Why change this?
-    description: Why would this make the vault better?
+    description: Why would this improve the project?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This repo is built on curiosity, creativity, and care — and *you* are part of 
 🪄 Whether you're a coder, documenter, designer, or dreamer — here are some great ways to help:
 
 - 📚 Improve documentation or fix typos  
-- 🐛 Report bugs (see our [Bug Report Template](.github/ISSUE_TEMPLATE/bug_report.yml))  
+- 🐛 Report bugs (see our [Bug Report Template](https://github.com/your-username/vault-image-description/issues/new?template=bug.yml))
 - 🌟 Suggest new features or enhancements  
 - 🧪 Write or improve tests  
 - 🔧 Refactor or optimize code  

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ We welcome contributions of all kinds!
 
 Use these links to get started:
 
-- [🐛 Bug Reports](./.github/ISSUE_TEMPLATE/bug_report.md)
-- [🌟 Feature Requests](./.github/ISSUE_TEMPLATE/feature_request.md)
+- [🐛 Bug Reports](https://github.com/your-username/vault-image-description/issues/new?template=bug.yml)
+- [🌟 Feature Requests](https://github.com/your-username/vault-image-description/issues/new?template=feature-request.yml)
 - [📦 Pull Requests](./.github/PULL_REQUEST_TEMPLATE.md)
 
 Read our [CONTRIBUTING.md](CONTRIBUTING.md) for more info, or start a conversation in [💬 GitHub Discussions](https://github.com/your-username/vault-image-description/discussions).


### PR DESCRIPTION
## Summary
- make issue templates refer to a generic project
- update links to use the yaml templates